### PR TITLE
Create transition state visualizer with custom server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-Create a pedagogical tool for visualizing transition state theory. It should display a potential energy surface (3D plot) using three.js, with some sliders for creating gaussian potentials, and then calculate the transition state boundary between state A and state B. These states should be circular regions of the PES. It should use NEB to find the path between states and umbrella sampling along the path. Backend should be Python, but output should be HTML and three.js.
+# Transition State Theory Visualizer
+
+This project implements an interactive teaching tool for exploring transition state theory concepts on top of a configurable two-dimensional potential energy surface (PES). The backend is a lightweight Python HTTP server, while the frontend uses HTML and [three.js](https://threejs.org/) for real-time 3D rendering.
+
+## Features
+
+- **Gaussian Potential Builder** – combine up to three Gaussian features via sliders to create custom PES landscapes.
+- **Circular States** – visualise two metastable states (A and B) as circular regions on the surface.
+- **Nudged Elastic Band (NEB)** – compute a minimum-energy path between states and highlight the transition state along the path.
+- **Transition Boundary Estimation** – approximate the dividing surface using an iso-energy contour around the transition state energy.
+- **Umbrella Sampling** – perform simple umbrella sampling around each NEB image and chart the resulting free-energy profile.
+
+## Getting started
+
+1. Launch the development server (no external dependencies are required):
+
+   ```bash
+   python -m app.server
+   ```
+
+2. Open the application in your browser at [http://localhost:5000](http://localhost:5000).
+
+Adjust the Gaussian sliders to reshape the PES. The NEB pathway, transition state and umbrella sampling analysis refresh automatically.
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+pytest
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,132 @@
+"""Core routines for constructing transition state theory visualisations."""
+from __future__ import annotations
+
+from typing import Any, Dict, Sequence
+
+from .neb import run_neb
+from .pes import (
+    CircularState,
+    GridSpec,
+    create_grid,
+    default_configuration,
+    evaluate_gradient_at_point,
+    evaluate_potential,
+    evaluate_potential_at_point,
+    grid_min_max,
+    parse_configuration,
+    transition_state_boundary,
+)
+from .sampling import umbrella_sampling
+
+
+def compute_visualisation(payload: Dict[str, Any]) -> Dict[str, Any]:
+    grid_spec, gaussians, state_a, state_b = parse_configuration(payload)
+    grid_x, grid_y, x_axis, y_axis = create_grid(grid_spec)
+    potential_values = evaluate_potential(grid_x, grid_y, gaussians)
+
+    def potential(point: Sequence[float]) -> float:
+        return evaluate_potential_at_point(point, gaussians)
+
+    def gradient(point: Sequence[float]):
+        return evaluate_gradient_at_point(point, gaussians)
+
+    start = _state_entry_point(grid_x, grid_y, potential_values, state_a)
+    end = _state_entry_point(grid_x, grid_y, potential_values, state_b)
+
+    neb_result = run_neb(
+        potential,
+        gradient,
+        start,
+        end,
+        n_images=18,
+        k_spring=2.5,
+        step_size=0.03,
+        max_iter=600,
+        force_tolerance=5e-4,
+    )
+
+    transition_idx = max(range(len(neb_result.energies)), key=lambda i: neb_result.energies[i])
+    transition_point = neb_result.path[transition_idx]
+    transition_energy = float(neb_result.energies[transition_idx])
+
+    boundary_points = transition_state_boundary(
+        grid_x, grid_y, potential_values, transition_energy, tolerance=0.15
+    )
+
+    umbrellas = umbrella_sampling(potential, neb_result.path)
+    z_min, z_max = grid_min_max(potential_values)
+
+    response = {
+        "grid": {
+            "x": x_axis,
+            "y": y_axis,
+            "z": potential_values,
+            "zMin": z_min,
+            "zMax": z_max,
+        },
+        "states": {
+            "A": {
+                "x0": state_a.x0,
+                "y0": state_a.y0,
+                "radius": state_a.radius,
+            },
+            "B": {
+                "x0": state_b.x0,
+                "y0": state_b.y0,
+                "radius": state_b.radius,
+            },
+        },
+        "path": [
+            {"x": point[0], "y": point[1], "z": energy}
+            for point, energy in zip(neb_result.path, neb_result.energies)
+        ],
+        "transitionState": {
+            "index": transition_idx,
+            "x": transition_point[0],
+            "y": transition_point[1],
+            "energy": transition_energy,
+        },
+        "boundary": boundary_points,
+        "umbrella": [
+            {
+                "index": window.center_index,
+                "reactionCoordinate": window.reaction_coordinate,
+                "freeEnergy": window.free_energy,
+                "samples": window.samples,
+            }
+            for window in umbrellas
+        ],
+        "meta": {
+            "nebIterations": neb_result.iterations,
+            "nebMaxForce": neb_result.max_force,
+        },
+    }
+    return response
+
+
+def _state_entry_point(
+    grid_x,
+    grid_y,
+    potential,
+    state: CircularState,
+) -> list[float]:
+    rows = len(grid_x)
+    cols = len(grid_x[0]) if rows else 0
+    best_point = [state.x0, state.y0]
+    best_energy = float("inf")
+    for row in range(rows):
+        for col in range(cols):
+            x_val = grid_x[row][col]
+            y_val = grid_y[row][col]
+            if (x_val - state.x0) ** 2 + (y_val - state.y0) ** 2 <= state.radius**2:
+                energy = potential[row][col]
+                if energy < best_energy:
+                    best_energy = energy
+                    best_point = [x_val, y_val]
+    return best_point
+
+
+__all__ = [
+    "compute_visualisation",
+    "default_configuration",
+]

--- a/app/neb.py
+++ b/app/neb.py
@@ -1,0 +1,78 @@
+"""Nudged elastic band implementation using only the standard library."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Sequence
+import math
+
+
+@dataclass
+class NEBResult:
+    path: List[List[float]]
+    energies: List[float]
+    gradients: List[List[float]]
+    iterations: int
+    max_force: float
+
+
+def run_neb(
+    potential: Callable[[Sequence[float]], float],
+    gradient: Callable[[Sequence[float]], Sequence[float]],
+    start: Sequence[float],
+    end: Sequence[float],
+    n_images: int = 20,
+    k_spring: float = 2.0,
+    step_size: float = 0.02,
+    max_iter: int = 400,
+    force_tolerance: float = 1e-3,
+) -> NEBResult:
+    """Run a lightweight NEB optimisation returning the discrete path."""
+
+    start = [float(start[0]), float(start[1])]
+    end = [float(end[0]), float(end[1])]
+    images: List[List[float]] = []
+    for index in range(n_images):
+        t = index / (n_images - 1)
+        images.append([
+            start[0] * (1 - t) + end[0] * t,
+            start[1] * (1 - t) + end[1] * t,
+        ])
+
+    forces: List[List[float]] = [[0.0, 0.0] for _ in range(n_images)]
+
+    for iteration in range(max_iter):
+        max_force = 0.0
+        for idx in range(1, n_images - 1):
+            prev_image = images[idx - 1]
+            next_image = images[idx + 1]
+            tangent = [next_image[0] - prev_image[0], next_image[1] - prev_image[1]]
+            tangent_norm = math.hypot(tangent[0], tangent[1])
+            if tangent_norm == 0:
+                tangent = [0.0, 0.0]
+            else:
+                tangent = [tangent[0] / tangent_norm, tangent[1] / tangent_norm]
+
+            grad = list(gradient(images[idx]))
+            grad_parallel_scalar = grad[0] * tangent[0] + grad[1] * tangent[1]
+            grad_parallel = [grad_parallel_scalar * tangent[0], grad_parallel_scalar * tangent[1]]
+            grad_perp = [grad[0] - grad_parallel[0], grad[1] - grad_parallel[1]]
+
+            dist_forward = math.hypot(next_image[0] - images[idx][0], next_image[1] - images[idx][1])
+            dist_backward = math.hypot(images[idx][0] - prev_image[0], images[idx][1] - prev_image[1])
+            spring_force_mag = k_spring * (dist_forward - dist_backward)
+            spring_force = [spring_force_mag * tangent[0], spring_force_mag * tangent[1]]
+
+            total_force = [-grad_perp[0] + spring_force[0], -grad_perp[1] + spring_force[1]]
+            forces[idx] = total_force
+            max_force = max(max_force, math.hypot(total_force[0], total_force[1]))
+
+        if max_force < force_tolerance:
+            break
+
+        for idx in range(1, n_images - 1):
+            images[idx][0] += step_size * forces[idx][0]
+            images[idx][1] += step_size * forces[idx][1]
+
+    energies = [float(potential(image)) for image in images]
+    gradients = [list(gradient(image)) for image in images]
+    return NEBResult(images, energies, gradients, iteration + 1, max_force)

--- a/app/pes.py
+++ b/app/pes.py
@@ -1,0 +1,235 @@
+"""Utilities for creating potential energy surfaces without external dependencies."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence, Tuple
+import math
+
+
+@dataclass
+class Gaussian:
+    """Parameters describing a 2D isotropic Gaussian potential."""
+
+    amplitude: float
+    sigma: float
+    x0: float
+    y0: float
+
+    @classmethod
+    def from_mapping(cls, mapping: dict) -> "Gaussian":
+        return cls(
+            amplitude=float(mapping.get("amplitude", 0.0)),
+            sigma=max(float(mapping.get("sigma", 1.0)), 1e-6),
+            x0=float(mapping.get("x0", 0.0)),
+            y0=float(mapping.get("y0", 0.0)),
+        )
+
+
+@dataclass
+class CircularState:
+    """A circular region that defines a metastable state."""
+
+    x0: float
+    y0: float
+    radius: float
+
+    @classmethod
+    def from_mapping(cls, mapping: dict) -> "CircularState":
+        radius = float(mapping.get("radius", 1.0))
+        if radius <= 0:
+            raise ValueError("State radius must be positive.")
+        return cls(
+            x0=float(mapping.get("x0", 0.0)),
+            y0=float(mapping.get("y0", 0.0)),
+            radius=radius,
+        )
+
+
+@dataclass
+class GridSpec:
+    """Description of the 2D grid on which the PES is evaluated."""
+
+    minimum: float
+    maximum: float
+    resolution: int
+
+    @classmethod
+    def from_mapping(cls, mapping: dict | None) -> "GridSpec":
+        if not mapping:
+            return cls(-4.0, 4.0, 60)
+        minimum = float(mapping.get("minimum", -4.0))
+        maximum = float(mapping.get("maximum", 4.0))
+        if maximum <= minimum:
+            raise ValueError("Grid maximum must be greater than the minimum.")
+        resolution = int(mapping.get("resolution", 60))
+        resolution = max(resolution, 10)
+        return cls(minimum, maximum, resolution)
+
+
+def _to_gaussians(items: Iterable[dict]) -> List[Gaussian]:
+    return [Gaussian.from_mapping(item) for item in items]
+
+
+def linspace(start: float, stop: float, num: int) -> List[float]:
+    if num == 1:
+        return [start]
+    step = (stop - start) / (num - 1)
+    return [start + step * i for i in range(num)]
+
+
+def create_grid(spec: GridSpec) -> Tuple[List[List[float]], List[List[float]], List[float], List[float]]:
+    """Create a mesh grid and return both the mesh and axis vectors."""
+
+    x_axis = linspace(spec.minimum, spec.maximum, spec.resolution)
+    y_axis = linspace(spec.minimum, spec.maximum, spec.resolution)
+    grid_x = [[x_axis[col] for col in range(spec.resolution)] for _ in range(spec.resolution)]
+    grid_y = [[y_axis[row] for _ in range(spec.resolution)] for row in range(spec.resolution)]
+    return grid_x, grid_y, x_axis, y_axis
+
+
+def evaluate_potential(
+    grid_x: Sequence[Sequence[float]],
+    grid_y: Sequence[Sequence[float]],
+    gaussians: Sequence[Gaussian],
+) -> List[List[float]]:
+    rows = len(grid_x)
+    cols = len(grid_x[0]) if rows else 0
+    potential = [[0.0 for _ in range(cols)] for _ in range(rows)]
+    for gaussian in gaussians:
+        sigma2 = gaussian.sigma * gaussian.sigma
+        for row in range(rows):
+            for col in range(cols):
+                dx = grid_x[row][col] - gaussian.x0
+                dy = grid_y[row][col] - gaussian.y0
+                r2 = dx * dx + dy * dy
+                potential[row][col] += gaussian.amplitude * math.exp(-0.5 * r2 / sigma2)
+    return potential
+
+
+def gradient_potential(
+    grid_x: Sequence[Sequence[float]],
+    grid_y: Sequence[Sequence[float]],
+    gaussians: Sequence[Gaussian],
+) -> Tuple[List[List[float]], List[List[float]]]:
+    rows = len(grid_x)
+    cols = len(grid_x[0]) if rows else 0
+    gx = [[0.0 for _ in range(cols)] for _ in range(rows)]
+    gy = [[0.0 for _ in range(cols)] for _ in range(rows)]
+    for gaussian in gaussians:
+        sigma2 = gaussian.sigma * gaussian.sigma
+        for row in range(rows):
+            for col in range(cols):
+                dx = grid_x[row][col] - gaussian.x0
+                dy = grid_y[row][col] - gaussian.y0
+                r2 = dx * dx + dy * dy
+                coeff = gaussian.amplitude * math.exp(-0.5 * r2 / sigma2) / sigma2
+                gx[row][col] += -dx * coeff
+                gy[row][col] += -dy * coeff
+    return gx, gy
+
+
+def evaluate_potential_at_point(point: Sequence[float], gaussians: Sequence[Gaussian]) -> float:
+    x, y = point
+    value = 0.0
+    for gaussian in gaussians:
+        dx = x - gaussian.x0
+        dy = y - gaussian.y0
+        sigma2 = gaussian.sigma * gaussian.sigma
+        r2 = dx * dx + dy * dy
+        value += gaussian.amplitude * math.exp(-0.5 * r2 / sigma2)
+    return value
+
+
+def evaluate_gradient_at_point(point: Sequence[float], gaussians: Sequence[Gaussian]) -> List[float]:
+    x, y = point
+    gx = 0.0
+    gy = 0.0
+    for gaussian in gaussians:
+        dx = x - gaussian.x0
+        dy = y - gaussian.y0
+        sigma2 = gaussian.sigma * gaussian.sigma
+        r2 = dx * dx + dy * dy
+        coeff = gaussian.amplitude * math.exp(-0.5 * r2 / sigma2) / sigma2
+        gx += -dx * coeff
+        gy += -dy * coeff
+    return [gx, gy]
+
+
+def state_masks(
+    grid_x: Sequence[Sequence[float]],
+    grid_y: Sequence[Sequence[float]],
+    state_a: CircularState,
+    state_b: CircularState,
+) -> Tuple[List[List[bool]], List[List[bool]]]:
+    rows = len(grid_x)
+    cols = len(grid_x[0]) if rows else 0
+    mask_a = [[False for _ in range(cols)] for _ in range(rows)]
+    mask_b = [[False for _ in range(cols)] for _ in range(rows)]
+    for row in range(rows):
+        for col in range(cols):
+            x = grid_x[row][col]
+            y = grid_y[row][col]
+            mask_a[row][col] = (x - state_a.x0) ** 2 + (y - state_a.y0) ** 2 <= state_a.radius**2
+            mask_b[row][col] = (x - state_b.x0) ** 2 + (y - state_b.y0) ** 2 <= state_b.radius**2
+    return mask_a, mask_b
+
+
+def transition_state_boundary(
+    grid_x: Sequence[Sequence[float]],
+    grid_y: Sequence[Sequence[float]],
+    potential: Sequence[Sequence[float]],
+    transition_energy: float,
+    tolerance: float,
+) -> List[List[float]]:
+    rows = len(grid_x)
+    cols = len(grid_x[0]) if rows else 0
+    points: List[List[float]] = []
+    for row in range(rows):
+        for col in range(cols):
+            if abs(potential[row][col] - transition_energy) <= tolerance:
+                points.append([grid_x[row][col], grid_y[row][col]])
+    return points
+
+
+def default_configuration() -> dict:
+    """Return a configuration with three Gaussian features and two states."""
+
+    return {
+        "grid": {"minimum": -4.0, "maximum": 4.0, "resolution": 60},
+        "gaussians": [
+            {"amplitude": 4.0, "sigma": 1.2, "x0": -1.5, "y0": 0.0},
+            {"amplitude": -6.5, "sigma": 0.8, "x0": 0.0, "y0": 0.0},
+            {"amplitude": 5.0, "sigma": 1.0, "x0": 1.8, "y0": 0.6},
+        ],
+        "stateA": {"x0": -2.5, "y0": 0.0, "radius": 0.6},
+        "stateB": {"x0": 2.4, "y0": 0.4, "radius": 0.6},
+    }
+
+
+def parse_configuration(payload: dict) -> tuple[
+    GridSpec, List[Gaussian], CircularState, CircularState
+]:
+    """Parse input payload into strongly typed objects."""
+
+    grid = GridSpec.from_mapping(payload.get("grid"))
+    gaussians = _to_gaussians(payload.get("gaussians", []))
+    if not gaussians:
+        gaussians = _to_gaussians(default_configuration()["gaussians"])
+    state_a = CircularState.from_mapping(payload.get("stateA", {}))
+    state_b = CircularState.from_mapping(payload.get("stateB", {}))
+    return grid, gaussians, state_a, state_b
+
+
+def grid_min_max(values: Sequence[Sequence[float]]) -> tuple[float, float]:
+    min_val = float("inf")
+    max_val = float("-inf")
+    for row in values:
+        for value in row:
+            if value < min_val:
+                min_val = value
+            if value > max_val:
+                max_val = value
+    if min_val == float("inf"):
+        min_val = 0.0
+        max_val = 0.0
+    return min_val, max_val

--- a/app/sampling.py
+++ b/app/sampling.py
@@ -1,0 +1,99 @@
+"""Umbrella sampling utilities implemented without third-party dependencies."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Sequence
+import math
+import random
+
+
+@dataclass
+class UmbrellaWindow:
+    center_index: int
+    reaction_coordinate: float
+    free_energy: float
+    samples: List[dict]
+
+
+def umbrella_sampling(
+    potential: Callable[[Sequence[float]], float],
+    path: Sequence[Sequence[float]],
+    beta: float = 1.0,
+    spring_constant: float = 5.0,
+    window_half_width: float = 0.5,
+    samples_per_window: int = 120,
+) -> List[UmbrellaWindow]:
+    """Perform a lightweight umbrella sampling around the points of a path."""
+
+    rng = random.Random(42)
+    windows: List[UmbrellaWindow] = []
+    total_images = len(path)
+
+    for idx, point in enumerate(path):
+        tangent = _estimate_tangent(path, idx)
+        perp = [-tangent[1], tangent[0]]
+        perp_norm = math.hypot(perp[0], perp[1])
+        if perp_norm == 0:
+            perp = [0.0, 1.0]
+        else:
+            perp = [perp[0] / perp_norm, perp[1] / perp_norm]
+
+        samples = []
+        weights = []
+        energies = []
+        for _ in range(samples_per_window):
+            displacement_along = rng.gauss(0.0, window_half_width / 2.0)
+            displacement_perp = rng.gauss(0.0, window_half_width)
+            sample_point = [
+                point[0] + displacement_along * tangent[0] + displacement_perp * perp[0],
+                point[1] + displacement_along * tangent[1] + displacement_perp * perp[1],
+            ]
+            potential_energy = float(potential(sample_point))
+            dx = sample_point[0] - point[0]
+            dy = sample_point[1] - point[1]
+            bias_energy = 0.5 * spring_constant * (dx * dx + dy * dy)
+            weight = math.exp(-beta * (potential_energy + bias_energy))
+            samples.append(
+                {
+                    "x": float(sample_point[0]),
+                    "y": float(sample_point[1]),
+                    "potential": potential_energy,
+                    "bias": bias_energy,
+                }
+            )
+            weights.append(weight)
+            energies.append(potential_energy)
+
+        partition = sum(weights)
+        if partition == 0:
+            free_energy = float("nan")
+        else:
+            expectation = sum(
+                w * math.exp(-beta * e) for w, e in zip(weights, energies)
+            ) / partition
+            free_energy = -math.log(max(expectation, 1e-12)) / beta
+
+        reaction_coordinate = idx / (total_images - 1) if total_images > 1 else 0.0
+        windows.append(
+            UmbrellaWindow(
+                center_index=idx,
+                reaction_coordinate=reaction_coordinate,
+                free_energy=free_energy,
+                samples=samples,
+            )
+        )
+
+    return windows
+
+
+def _estimate_tangent(path: Sequence[Sequence[float]], idx: int) -> List[float]:
+    if idx == 0:
+        tangent = [path[1][0] - path[0][0], path[1][1] - path[0][1]]
+    elif idx == len(path) - 1:
+        tangent = [path[-1][0] - path[-2][0], path[-1][1] - path[-2][1]]
+    else:
+        tangent = [path[idx + 1][0] - path[idx - 1][0], path[idx + 1][1] - path[idx - 1][1]]
+    norm = math.hypot(tangent[0], tangent[1])
+    if norm == 0:
+        return [1.0, 0.0]
+    return [tangent[0] / norm, tangent[1] / norm]

--- a/app/server.py
+++ b/app/server.py
@@ -1,0 +1,77 @@
+"""Minimal HTTP server for the transition state visualiser."""
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict
+
+from . import compute_visualisation, default_configuration
+
+
+def _load_index_template() -> str:
+    template_path = Path(__file__).parent / "templates" / "index.html"
+    return template_path.read_text(encoding="utf-8")
+
+
+INDEX_TEMPLATE = _load_index_template()
+DEFAULT_CONFIG_JSON = json.dumps(default_configuration())
+
+
+class TransitionStateHandler(BaseHTTPRequestHandler):
+    server_version = "TransitionStateServer/1.0"
+
+    def _set_common_headers(self, status: HTTPStatus = HTTPStatus.OK, content_type: str = "application/json") -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+
+    def do_OPTIONS(self) -> None:  # noqa: N802 - required name by BaseHTTPRequestHandler
+        self._set_common_headers()
+        self.end_headers()
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/" or self.path == "/index.html":
+            content = INDEX_TEMPLATE.replace("__DEFAULT_CONFIG__", DEFAULT_CONFIG_JSON)
+            encoded = content.encode("utf-8")
+            self._set_common_headers(content_type="text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+        else:
+            self.send_error(HTTPStatus.NOT_FOUND, "Resource not found")
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/api/pes":
+            self.send_error(HTTPStatus.NOT_FOUND, "Resource not found")
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length).decode("utf-8") if length else "{}"
+        try:
+            payload: Dict[str, Any] = json.loads(body or "{}")
+        except json.JSONDecodeError:
+            self.send_error(HTTPStatus.BAD_REQUEST, "Invalid JSON payload")
+            return
+        response = compute_visualisation(payload)
+        encoded = json.dumps(response).encode("utf-8")
+        self._set_common_headers()
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+def run(host: str = "127.0.0.1", port: int = 5000) -> None:
+    server = ThreadingHTTPServer((host, port), TransitionStateHandler)
+    print(f"Serving Transition State Visualiser on http://{host}:{port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down server…")
+    finally:
+        server.server_close()
+
+
+__all__ = ["run"]

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,615 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Transition State Theory Visualizer</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        font-family: "Inter", Arial, sans-serif;
+        color: #1f2933;
+        background-color: #f8fafc;
+      }
+
+      body {
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+      }
+
+      header {
+        padding: 1.2rem 1.5rem;
+        background: linear-gradient(90deg, #0f172a, #1e293b);
+        color: #f9fafb;
+        box-shadow: 0 2px 4px rgba(15, 23, 42, 0.2);
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: 1.8rem;
+      }
+
+      main {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        padding: 1rem 1.5rem 2rem;
+        gap: 1rem;
+      }
+
+      #layout {
+        display: grid;
+        grid-template-columns: minmax(260px, 320px) minmax(400px, 1fr);
+        gap: 1.25rem;
+      }
+
+      #controls, #analysis {
+        background: #ffffff;
+        border-radius: 12px;
+        box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+        padding: 1.25rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      #viewer {
+        position: relative;
+        background: #0f172a;
+        border-radius: 12px;
+        overflow: hidden;
+        min-height: 520px;
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+      }
+
+      #viewer canvas {
+        display: block;
+      }
+
+      fieldset {
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        border-radius: 10px;
+        padding: 0.75rem 1rem 1rem;
+        background: rgba(241, 245, 249, 0.35);
+      }
+
+      legend {
+        font-weight: 600;
+        padding: 0 0.25rem;
+      }
+
+      .control {
+        display: flex;
+        flex-direction: column;
+        margin-bottom: 0.65rem;
+      }
+
+      .control label {
+        font-size: 0.85rem;
+        font-weight: 600;
+        display: flex;
+        justify-content: space-between;
+        color: #334155;
+      }
+
+      .control input[type="range"] {
+        width: 100%;
+      }
+
+      .control output {
+        font-weight: 500;
+      }
+
+      .state-info {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.75rem;
+      }
+
+      .state-card {
+        background: rgba(226, 232, 240, 0.4);
+        border-radius: 10px;
+        padding: 0.75rem;
+        border: 1px solid rgba(148, 163, 184, 0.45);
+      }
+
+      .state-card h3 {
+        margin: 0 0 0.35rem;
+        font-size: 0.95rem;
+      }
+
+      #meta-info {
+        display: grid;
+        gap: 0.6rem;
+        font-size: 0.9rem;
+      }
+
+      #meta-info strong {
+        color: #0f172a;
+      }
+
+      #chart-wrapper {
+        background: rgba(241, 245, 249, 0.6);
+        border-radius: 10px;
+        padding: 0.75rem;
+        border: 1px solid rgba(203, 213, 225, 0.6);
+      }
+
+      #umbrella-details summary {
+        cursor: pointer;
+        font-weight: 600;
+        color: #1e3a8a;
+      }
+
+      #umbrella-details {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        max-height: 240px;
+        overflow-y: auto;
+        padding-right: 0.5rem;
+      }
+
+      #status-panel {
+        background: rgba(30, 41, 59, 0.85);
+        color: #f8fafc;
+        position: absolute;
+        bottom: 1rem;
+        left: 1rem;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        font-size: 0.85rem;
+        box-shadow: 0 6px 16px rgba(15, 23, 42, 0.35);
+        pointer-events: none;
+        opacity: 0.92;
+      }
+
+      @media (max-width: 900px) {
+        #layout {
+          grid-template-columns: 1fr;
+        }
+
+        #viewer {
+          min-height: 400px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Transition State Theory Visualizer</h1>
+      <p style="margin: 0; opacity: 0.8; font-size: 0.95rem;">
+        Explore potential energy surfaces, minimum energy pathways and umbrella sampling interactively.
+      </p>
+    </header>
+    <main>
+      <div id="layout">
+        <section id="controls">
+          <h2 style="margin: 0; font-size: 1.2rem;">Gaussian Potentials</h2>
+          <p style="margin: 0; font-size: 0.9rem; color: #475569;">
+            Adjust the amplitudes, widths and positions of the Gaussian features to reshape the potential energy surface.
+          </p>
+          <div id="gaussian-controls"></div>
+          <button id="reset-button" style="padding: 0.6rem 1rem; border-radius: 999px; border: none; background: #1d4ed8; color: white; font-weight: 600; cursor: pointer; align-self: flex-start;">
+            Reset to defaults
+          </button>
+        </section>
+        <div id="viewer">
+          <div id="status-panel">
+            <div><strong>Transition energy:</strong> <span id="transition-energy">–</span></div>
+            <div><strong>Reaction coordinate:</strong> <span id="transition-coordinate">–</span></div>
+            <div><strong>NEB iterations:</strong> <span id="neb-iterations">–</span></div>
+          </div>
+        </div>
+      </div>
+      <section id="analysis">
+        <h2 style="margin: 0; font-size: 1.2rem;">Analysis</h2>
+        <div id="meta-info">
+          <div class="state-info">
+            <div class="state-card" style="border-color: rgba(14,116,144,0.45);">
+              <h3>State A</h3>
+              <div>Center: (<span id="stateA-x">0</span>, <span id="stateA-y">0</span>)</div>
+              <div>Radius: <span id="stateA-radius">0</span></div>
+            </div>
+            <div class="state-card" style="border-color: rgba(220,38,38,0.45);">
+              <h3>State B</h3>
+              <div>Center: (<span id="stateB-x">0</span>, <span id="stateB-y">0</span>)</div>
+              <div>Radius: <span id="stateB-radius">0</span></div>
+            </div>
+          </div>
+          <div id="chart-wrapper">
+            <h3 style="margin: 0 0 0.5rem;">Umbrella Sampling Free Energy</h3>
+            <canvas id="freeEnergyChart" height="220"></canvas>
+          </div>
+          <div>
+            <h3 style="margin: 0 0 0.5rem;">Sampling windows</h3>
+            <div id="umbrella-details"></div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/three@0.157.0/build/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.157.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <script>
+      const defaultConfig = __DEFAULT_CONFIG__;
+      let currentConfig = JSON.parse(JSON.stringify(defaultConfig));
+      let activeRequest = null;
+      let surfaceMesh = null;
+      let pathLine = null;
+      let boundaryLine = null;
+      let transitionMarker = null;
+      let stateMeshes = { A: null, B: null };
+      let verticalScale = 1.0;
+      let zMinimum = 0.0;
+      let freeEnergyChart = null;
+
+      const viewer = document.getElementById("viewer");
+      const renderer = new THREE.WebGLRenderer({ antialias: true });
+      renderer.setPixelRatio(window.devicePixelRatio);
+      renderer.setSize(viewer.clientWidth, viewer.clientHeight);
+      viewer.appendChild(renderer.domElement);
+
+      const scene = new THREE.Scene();
+      scene.background = new THREE.Color(0x0f172a);
+
+      const camera = new THREE.PerspectiveCamera(
+        48,
+        viewer.clientWidth / viewer.clientHeight,
+        0.1,
+        100
+      );
+      camera.position.set(7, 7, 7);
+
+      const controls = new THREE.OrbitControls(camera, renderer.domElement);
+      controls.enableDamping = true;
+
+      const ambientLight = new THREE.AmbientLight(0xffffff, 0.55);
+      scene.add(ambientLight);
+      const directionalLight = new THREE.DirectionalLight(0xffffff, 0.9);
+      directionalLight.position.set(8, 12, 6);
+      scene.add(directionalLight);
+
+      const gridHelper = new THREE.GridHelper(12, 12, 0x334155, 0x1f2937);
+      scene.add(gridHelper);
+
+      function buildGaussianControls() {
+        const container = document.getElementById("gaussian-controls");
+        container.innerHTML = "";
+        currentConfig.gaussians.forEach((gaussian, index) => {
+          const fieldset = document.createElement("fieldset");
+          const legend = document.createElement("legend");
+          legend.textContent = `Gaussian ${index + 1}`;
+          fieldset.appendChild(legend);
+
+          const controls = [
+            { key: "amplitude", label: "Amplitude", min: -10, max: 10, step: 0.1 },
+            { key: "sigma", label: "Width (sigma)", min: 0.2, max: 3, step: 0.05 },
+            { key: "x0", label: "Center X", min: -4, max: 4, step: 0.1 },
+            { key: "y0", label: "Center Y", min: -4, max: 4, step: 0.1 },
+          ];
+
+          controls.forEach(({ key, label, min, max, step }) => {
+            const wrapper = document.createElement("div");
+            wrapper.className = "control";
+            const inputId = `g-${index}-${key}`;
+            const controlLabel = document.createElement("label");
+            controlLabel.setAttribute("for", inputId);
+            const output = document.createElement("output");
+            output.id = `${inputId}-value`;
+            output.textContent = gaussian[key].toFixed(2);
+            controlLabel.textContent = label;
+            controlLabel.appendChild(output);
+
+            const input = document.createElement("input");
+            input.type = "range";
+            input.min = String(min);
+            input.max = String(max);
+            input.step = String(step);
+            input.value = gaussian[key];
+            input.id = inputId;
+            input.addEventListener("input", (event) => {
+              const value = parseFloat(event.target.value);
+              currentConfig.gaussians[index][key] = value;
+              output.textContent = value.toFixed(2);
+            });
+            input.addEventListener("change", () => {
+              debounceFetch();
+            });
+
+            wrapper.appendChild(controlLabel);
+            wrapper.appendChild(input);
+            fieldset.appendChild(wrapper);
+          });
+
+          container.appendChild(fieldset);
+        });
+      }
+
+      let debounceTimer = null;
+      function debounceFetch() {
+        if (debounceTimer) {
+          clearTimeout(debounceTimer);
+        }
+        debounceTimer = setTimeout(() => {
+          requestSurfaceUpdate();
+        }, 180);
+      }
+
+      function requestSurfaceUpdate() {
+        if (activeRequest) {
+          activeRequest.abort();
+        }
+        const controller = new AbortController();
+        activeRequest = controller;
+        fetch("/api/pes", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(currentConfig),
+          signal: controller.signal,
+        })
+          .then((response) => response.json())
+          .then((data) => {
+            activeRequest = null;
+            updateScene(data);
+          })
+          .catch((error) => {
+            if (error.name !== "AbortError") {
+              console.error("Failed to update PES", error);
+            }
+          });
+      }
+
+      function updateScene(data) {
+        const grid = data.grid;
+        zMinimum = grid.zMin;
+        const energyRange = Math.max(grid.zMax - grid.zMin, 1e-3);
+        verticalScale = 3.0 / energyRange;
+        updateSurface(grid);
+        updateStates(data.states);
+        updatePath(data.path, data.transitionState);
+        updateBoundary(data.boundary);
+        updateMeta(data);
+        updateUmbrella(data.umbrella);
+      }
+
+      function updateSurface(grid) {
+        if (surfaceMesh) {
+          scene.remove(surfaceMesh);
+          surfaceMesh.geometry.dispose();
+          surfaceMesh.material.dispose();
+        }
+        const xVals = grid.x;
+        const yVals = grid.y;
+        const zVals = grid.z;
+        const rows = yVals.length;
+        const cols = xVals.length;
+        const geometry = new THREE.BufferGeometry();
+        const positions = new Float32Array(rows * cols * 3);
+        let ptr = 0;
+        for (let row = 0; row < rows; row++) {
+          for (let col = 0; col < cols; col++) {
+            const height = (zVals[row][col] - zMinimum) * verticalScale;
+            positions[ptr++] = xVals[col];
+            positions[ptr++] = height;
+            positions[ptr++] = yVals[row];
+          }
+        }
+        const indices = [];
+        for (let row = 0; row < rows - 1; row++) {
+          for (let col = 0; col < cols - 1; col++) {
+            const a = row * cols + col;
+            const b = row * cols + (col + 1);
+            const c = (row + 1) * cols + col;
+            const d = (row + 1) * cols + (col + 1);
+            indices.push(a, c, b);
+            indices.push(b, c, d);
+          }
+        }
+        geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+        geometry.setIndex(indices);
+        geometry.computeVertexNormals();
+
+        const material = new THREE.MeshStandardMaterial({
+          color: 0x5eead4,
+          emissive: 0x0f172a,
+          roughness: 0.35,
+          metalness: 0.05,
+          side: THREE.DoubleSide,
+        });
+
+        surfaceMesh = new THREE.Mesh(geometry, material);
+        scene.add(surfaceMesh);
+      }
+
+      function updateStates(states) {
+        const planeHeight = 0.02;
+        ["A", "B"].forEach((key) => {
+          const state = states[key];
+          if (!state) return;
+          if (stateMeshes[key]) {
+            scene.remove(stateMeshes[key]);
+          }
+          const color = key === "A" ? 0x0891b2 : 0xdc2626;
+          const geometry = new THREE.CircleGeometry(state.radius, 48);
+          const material = new THREE.MeshBasicMaterial({
+            color,
+            transparent: true,
+            opacity: 0.35,
+            side: THREE.DoubleSide,
+          });
+          const mesh = new THREE.Mesh(geometry, material);
+          mesh.rotation.x = -Math.PI / 2;
+          mesh.position.set(state.x0, planeHeight, state.y0);
+          scene.add(mesh);
+          stateMeshes[key] = mesh;
+        });
+        document.getElementById("stateA-x").textContent = states.A.x0.toFixed(2);
+        document.getElementById("stateA-y").textContent = states.A.y0.toFixed(2);
+        document.getElementById("stateA-radius").textContent = states.A.radius.toFixed(2);
+        document.getElementById("stateB-x").textContent = states.B.x0.toFixed(2);
+        document.getElementById("stateB-y").textContent = states.B.y0.toFixed(2);
+        document.getElementById("stateB-radius").textContent = states.B.radius.toFixed(2);
+      }
+
+      function updatePath(path, transitionState) {
+        if (pathLine) {
+          scene.remove(pathLine);
+        }
+        if (transitionMarker) {
+          scene.remove(transitionMarker);
+        }
+        const points = path.map((point) =>
+          new THREE.Vector3(
+            point.x,
+            (point.z - zMinimum) * verticalScale,
+            point.y
+          )
+        );
+        const geometry = new THREE.BufferGeometry().setFromPoints(points);
+        const material = new THREE.LineBasicMaterial({ color: 0xf97316, linewidth: 3 });
+        pathLine = new THREE.Line(geometry, material);
+        scene.add(pathLine);
+
+        if (transitionState) {
+          const sphereGeom = new THREE.SphereGeometry(0.12, 32, 32);
+          const sphereMat = new THREE.MeshStandardMaterial({ color: 0xfbbf24, emissive: 0xb45309 });
+          transitionMarker = new THREE.Mesh(sphereGeom, sphereMat);
+          const height = (transitionState.energy - zMinimum) * verticalScale;
+          transitionMarker.position.set(
+            transitionState.x,
+            height,
+            transitionState.y
+          );
+          scene.add(transitionMarker);
+        }
+      }
+
+      function updateBoundary(boundaryPoints) {
+        if (boundaryLine) {
+          scene.remove(boundaryLine);
+        }
+        if (!boundaryPoints || boundaryPoints.length === 0) {
+          return;
+        }
+        const curvePoints = boundaryPoints.map((pt) =>
+          new THREE.Vector3(pt[0], 0.05, pt[1])
+        );
+        const geometry = new THREE.BufferGeometry().setFromPoints(curvePoints);
+        const material = new THREE.LineDashedMaterial({
+          color: 0x38bdf8,
+          dashSize: 0.2,
+          gapSize: 0.12,
+          linewidth: 1,
+        });
+        boundaryLine = new THREE.Line(geometry, material);
+        boundaryLine.computeLineDistances();
+        scene.add(boundaryLine);
+      }
+
+      function updateMeta(data) {
+        const transition = data.transitionState;
+        if (transition) {
+          document.getElementById("transition-energy").textContent = transition.energy.toFixed(3);
+          const coordFraction = data.path.length > 1 ? (transition.index / (data.path.length - 1)).toFixed(2) : '0.00';
+          document.getElementById("transition-coordinate").textContent = `(${transition.x.toFixed(2)}, ${transition.y.toFixed(2)}) — s=${coordFraction}`;
+        }
+        document.getElementById("neb-iterations").textContent = data.meta.nebIterations;
+      }
+
+      function updateUmbrella(windows) {
+        if (!windows || windows.length === 0) {
+          return;
+        }
+        const reactionCoords = windows.map((window) => window.reactionCoordinate);
+        const freeEnergies = windows.map((window) => window.freeEnergy);
+        const ctx = document.getElementById("freeEnergyChart");
+        if (!freeEnergyChart) {
+          freeEnergyChart = new Chart(ctx, {
+            type: "line",
+            data: {
+              labels: reactionCoords,
+              datasets: [
+                {
+                  label: "Free energy (kT)",
+                  data: freeEnergies,
+                  fill: false,
+                  borderColor: "#2563eb",
+                  tension: 0.2,
+                },
+              ],
+            },
+            options: {
+              scales: {
+                x: {
+                  title: { display: true, text: "Reaction coordinate" },
+                },
+                y: {
+                  title: { display: true, text: "Free energy" },
+                },
+              },
+              plugins: {
+                legend: { display: false },
+              },
+            },
+          });
+        } else {
+          freeEnergyChart.data.labels = reactionCoords;
+          freeEnergyChart.data.datasets[0].data = freeEnergies;
+          freeEnergyChart.update();
+        }
+        const detailsContainer = document.getElementById("umbrella-details");
+        detailsContainer.innerHTML = "";
+        windows.forEach((window) => {
+          const summary = document.createElement("details");
+          const header = document.createElement("summary");
+          header.textContent = `Window ${window.index + 1} — reaction coordinate ${window.reactionCoordinate.toFixed(2)}`;
+          summary.appendChild(header);
+          const list = document.createElement("ul");
+          list.style.margin = "0.3rem 0 0.5rem";
+          list.style.paddingLeft = "1.1rem";
+          list.style.fontSize = "0.85rem";
+
+          const sample = window.samples[0];
+          const li = document.createElement("li");
+          li.textContent = `Representative sample at (${sample.x.toFixed(2)}, ${sample.y.toFixed(2)}), potential ${sample.potential.toFixed(2)}.`;
+          list.appendChild(li);
+
+          const li2 = document.createElement("li");
+          li2.textContent = `Estimated free energy: ${window.freeEnergy.toFixed(3)} kT.`;
+          list.appendChild(li2);
+
+          summary.appendChild(list);
+          detailsContainer.appendChild(summary);
+        });
+      }
+
+      function animate() {
+        requestAnimationFrame(animate);
+        controls.update();
+        renderer.render(scene, camera);
+      }
+
+      function handleResize() {
+        const width = viewer.clientWidth;
+        const height = viewer.clientHeight;
+        renderer.setSize(width, height);
+        camera.aspect = width / height;
+        camera.updateProjectionMatrix();
+      }
+
+      window.addEventListener("resize", handleResize);
+      document.getElementById("reset-button").addEventListener("click", () => {
+        currentConfig = JSON.parse(JSON.stringify(defaultConfig));
+        buildGaussianControls();
+        requestSurfaceUpdate();
+      });
+
+      buildGaussianControls();
+      requestSurfaceUpdate();
+      animate();
+    </script>
+  </body>
+</html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_neb.py
+++ b/tests/test_neb.py
@@ -1,0 +1,45 @@
+import math
+
+from app.neb import run_neb
+from app.pes import Gaussian
+
+
+GAUSSIANS = [
+    Gaussian(amplitude=-6.0, sigma=1.0, x0=0.0, y0=0.0),
+    Gaussian(amplitude=3.0, sigma=0.5, x0=1.5, y0=0.0),
+]
+
+
+def potential(point):
+    x, y = point
+    value = 0.0
+    for gaussian in GAUSSIANS:
+        dx = x - gaussian.x0
+        dy = y - gaussian.y0
+        r2 = dx * dx + dy * dy
+        sigma2 = gaussian.sigma * gaussian.sigma
+        value += gaussian.amplitude * math.exp(-0.5 * r2 / sigma2)
+    return value
+
+
+def gradient(point):
+    x, y = point
+    gx = 0.0
+    gy = 0.0
+    for gaussian in GAUSSIANS:
+        dx = x - gaussian.x0
+        dy = y - gaussian.y0
+        r2 = dx * dx + dy * dy
+        sigma2 = gaussian.sigma * gaussian.sigma
+        coeff = gaussian.amplitude * math.exp(-0.5 * r2 / sigma2) / sigma2
+        gx += -dx * coeff
+        gy += -dy * coeff
+    return [gx, gy]
+
+
+def test_neb_returns_path():
+    result = run_neb(potential, gradient, start=(-2.0, 0.0), end=(2.0, 0.0), n_images=12, max_iter=50)
+    assert len(result.path) == 12
+    assert all(len(point) == 2 for point in result.path)
+    assert all(math.isfinite(energy) for energy in result.energies)
+    assert result.iterations <= 50

--- a/tests/test_pes.py
+++ b/tests/test_pes.py
@@ -1,0 +1,37 @@
+from app.pes import (
+    Gaussian,
+    GridSpec,
+    create_grid,
+    evaluate_potential,
+    gradient_potential,
+    evaluate_gradient_at_point,
+    transition_state_boundary,
+)
+
+
+def max_in_grid(values):
+    return max(max(row) for row in values)
+
+
+def test_gaussian_potential_symmetry():
+    grid_spec = GridSpec(-2, 2, 20)
+    grid_x, grid_y, _, _ = create_grid(grid_spec)
+    gaussian = Gaussian(amplitude=5.0, sigma=0.5, x0=0.0, y0=0.0)
+    potential = evaluate_potential(grid_x, grid_y, [gaussian])
+    assert max_in_grid(potential) == potential[grid_spec.resolution // 2][grid_spec.resolution // 2]
+
+
+def test_gradient_is_zero_at_center():
+    gaussian = Gaussian(amplitude=5.0, sigma=0.5, x0=1.0, y0=-1.0)
+    gradient = evaluate_gradient_at_point((1.0, -1.0), [gaussian])
+    assert abs(gradient[0]) < 1e-8
+    assert abs(gradient[1]) < 1e-8
+
+
+def test_transition_state_boundary_extracts_points():
+    grid_spec = GridSpec(-2, 2, 10)
+    grid_x, grid_y, _, _ = create_grid(grid_spec)
+    gaussian = Gaussian(amplitude=3.0, sigma=0.6, x0=0.0, y0=0.0)
+    potential = evaluate_potential(grid_x, grid_y, [gaussian])
+    points = transition_state_boundary(grid_x, grid_y, potential, transition_energy=2.0, tolerance=0.5)
+    assert len(points) > 0


### PR DESCRIPTION
## Summary
- implement dependency-free Python modules for generating the PES, running NEB, and performing umbrella sampling
- add a lightweight HTTP server that serves the interactive three.js visualiser and exposes a `/api/pes` endpoint
- build a rich frontend with Gaussian sliders, pathway rendering, transition markers, and umbrella sampling charts, plus regression tests for the numerical helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce53abcb388324bb1ad8ea74f01533